### PR TITLE
[#8] [Feat] 관리자 회원 관리 기능 구현

### DIFF
--- a/src/main/java/com/example/dopamines/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/dopamines/domain/admin/controller/AdminController.java
@@ -1,0 +1,34 @@
+package com.example.dopamines.domain.admin.controller;
+
+import com.example.dopamines.domain.admin.model.request.AdminSignupRequest;
+import com.example.dopamines.domain.admin.model.request.UserAssignedRequest;
+import com.example.dopamines.domain.admin.model.request.UserBlackRequest;
+import com.example.dopamines.domain.admin.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PostMapping("/signup")
+    public void signupAdmin(@RequestBody AdminSignupRequest request) {
+        adminService.signupAdmin(request);
+    }
+
+    @PostMapping("/assign")
+    public void assignedUser(@RequestBody UserAssignedRequest request){
+        adminService.setUserStatus(request);
+    }
+
+    @PostMapping("/user/black")
+    public void assignedUser(@RequestBody UserBlackRequest request){
+        adminService.setBlackList(request);
+    }
+}

--- a/src/main/java/com/example/dopamines/domain/admin/model/request/AdminSignupRequest.java
+++ b/src/main/java/com/example/dopamines/domain/admin/model/request/AdminSignupRequest.java
@@ -1,0 +1,12 @@
+package com.example.dopamines.domain.admin.model.request;
+
+import lombok.Getter;
+
+@Getter
+public class AdminSignupRequest {
+    private String email;
+    private String password;
+    private String name;
+    private String nickname;
+    private String phoneNumber;
+}

--- a/src/main/java/com/example/dopamines/domain/admin/model/request/UserAssignedRequest.java
+++ b/src/main/java/com/example/dopamines/domain/admin/model/request/UserAssignedRequest.java
@@ -1,0 +1,9 @@
+package com.example.dopamines.domain.admin.model.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserAssignedRequest {
+    private Long idx;
+    private Integer courseNum;
+}

--- a/src/main/java/com/example/dopamines/domain/admin/model/request/UserBlackRequest.java
+++ b/src/main/java/com/example/dopamines/domain/admin/model/request/UserBlackRequest.java
@@ -1,0 +1,8 @@
+package com.example.dopamines.domain.admin.model.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserBlackRequest {
+    private Long idx;
+}

--- a/src/main/java/com/example/dopamines/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/dopamines/domain/admin/service/AdminService.java
@@ -1,0 +1,62 @@
+package com.example.dopamines.domain.admin.service;
+
+import com.example.dopamines.domain.admin.model.request.AdminSignupRequest;
+import com.example.dopamines.domain.admin.model.request.UserAssignedRequest;
+import com.example.dopamines.domain.admin.model.request.UserBlackRequest;
+import com.example.dopamines.domain.user.model.entity.User;
+import com.example.dopamines.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    
+    public void signupAdmin(AdminSignupRequest request) {
+        System.out.println(request.getEmail());
+        System.out.println(request.getPhoneNumber());
+        System.out.println(request.getPassword());
+        LocalDateTime localDateTime = LocalDateTime.now();
+        localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(bCryptPasswordEncoder.encode(request.getPassword()))
+                .name(request.getName())
+                .nickname(request.getNickname())
+                .phoneNumber(request.getPhoneNumber())
+                .address("-")
+                .role("ROLE_ADMIN")
+                .createdAt(localDateTime)
+                .updatedAt(localDateTime)
+                .build();
+        user.setActiveOn(true);
+        userRepository.save(user);
+    }
+
+    // -------------- user 정보 관리 --------------------
+    // 한화 수강생 승인 관리 (승인 버튼)
+    public void setUserStatus(UserAssignedRequest request){
+        Optional<User> result = userRepository.findById(request.getIdx());
+        if(!result.isPresent()){
+            User user = result.get();
+            user.activeHanwhaUser(request.getCourseNum());  // TEMPORARY_USER -> USER 변경
+            userRepository.save(user);
+        }
+    }
+    // 회원 활동 정지 (벤 버튼)
+    public void setBlackList(UserBlackRequest request){
+        Optional<User> result = userRepository.findById(request.getIdx());
+        if(!result.isPresent()){
+            User user = result.get();
+            user.setToBlackList();
+            userRepository.save(user);
+        }
+    }
+}

--- a/src/main/java/com/example/dopamines/domain/user/model/entity/User.java
+++ b/src/main/java/com/example/dopamines/domain/user/model/entity/User.java
@@ -19,7 +19,6 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
-
     @NotNull
     private String email;
 
@@ -73,10 +72,22 @@ public class User {
         this.phoneNumber = phoneNumber;
         this.address = address;
         this.socialLogined = false;
-//        this.status = status;     //사용 의도 미정
-//        this.courseNum = courseNum; // 관리자 등록 미정
+        this.status = true;
+        this.courseNum = null;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+    }
+
+    //Todo : Q)자체 로직으로 ADMIN 계정인지 확인할 지 고민
+    public void activeHanwhaUser(Integer courseNum){
+        this.status = true;
+        this.courseNum = courseNum;
+        this.role = "ROLE_USER";
+    }
+
+    //Todo : Q)자체 로직으로 ADMIN 계정인지 확인할 지 고민
+    public void setToBlackList(){
+        this.status = false;
     }
 
     // 이메일 검증

--- a/src/main/java/com/example/dopamines/global/security/CustomUserDetails.java
+++ b/src/main/java/com/example/dopamines/global/security/CustomUserDetails.java
@@ -12,13 +12,14 @@ import org.springframework.security.core.userdetails.UserDetails;
 public class CustomUserDetails implements UserDetails {
     private final User user;
 
+    //여러가지 role 을 보유했을 때, 확인 작업
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> collection = new ArrayList<>();
         collection.add(new GrantedAuthority(){
             @Override
             public String getAuthority() {
-                return "ROLE_USER";
+                return user.getRole();
             }
         });
         return collection;
@@ -34,10 +35,13 @@ public class CustomUserDetails implements UserDetails {
         return user.getEmail();
     }
 
-    //이메일 인증 실패하면 로그인 및 jwt 발급 실패
+    //이메일 인증 실패하거나,회원 정지 상태면 로그인 및 jwt 발급 실패
     @Override
     public boolean isEnabled() {
-        return user.isEnabled();
+        if(user.isEnabled() && user.isStatus()) {
+            return user.isEnabled();
+        }
+        return false;
     }
 
     public Long getIdx() {return user.getIdx();}

--- a/src/main/java/com/example/dopamines/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/dopamines/global/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.dopamines.global.security;
 
 
+import com.example.dopamines.domain.user.service.OAuth2Service;
 import com.example.dopamines.global.auth.OAuth2AuthenticaitonSuccessHandler;
 import com.example.dopamines.global.security.filter.JwtFilter;
 import com.example.dopamines.global.security.filter.LoginFilter;
@@ -58,8 +59,11 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests((auth) ->
                 auth
-                        .requestMatchers("/user/role-user").hasRole("USER")
-                        .requestMatchers("/user/role-admin").hasRole("ADMIN")
+                        .requestMatchers("/test/role-user").hasRole("USER")
+                        .requestMatchers("/test/role-temporary").hasRole("TEMPORARY_USER")
+                        .requestMatchers("/test/role-admin").hasRole("ADMIN")
+                        .requestMatchers("/admin/assign","/admin/user/black").hasRole("ADMIN")
+                        .requestMatchers("/admin/signup").permitAll()
                         .anyRequest().permitAll()
         );
 


### PR DESCRIPTION
## 💭 연관된 이슈
<br>
#8 

## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!-- Resolves: #(Isuue Number) -->

<br>

- 수강생 인증을 마친 회원에 대해서, 커뮤니티 이용 가능 권한 부여.  
- 특정 회원에 대해서 블랙리스트 기능 추가

## ✅ 주요구현 기능

<br>

- 일반 회원가입을 하면 TEMPORARY_USER 의 권한을 받는 유저가, 수강생 인증을 마치게 되면,
관리자가 회원의 권한을 USER 로 등급을 올릴 수 있는 기능을 추가하였습니다.
![image](https://github.com/user-attachments/assets/e745a409-57a3-490b-8f14-ba4428447c1a)


- 특정 회원에 대해서 블랙 기능을 추가하여, 블랙을 먹은 회원은 어떠한 기능도 이용할 수 없도록 하였습니다.
![image](https://github.com/user-attachments/assets/8edaeb5a-4940-4ef5-9593-cbd73ce29034)


## 🍪 수정이 되면 좋은 것들

<br>

ADMIN 권한을 가진 사용자 내에서 해당 기능들을 사용할 수 있도록 하였으나, USER entity 자체에서 해당 기능을 setter 로 열어둠으로서 위험도가 증가하였습니다. 
추후, 해당 내용에 대해서 자체적으로 권한여부를 체크해야 할 지에 대한 논의가 필요됩니다.

![image](https://github.com/user-attachments/assets/1cbddc71-178b-477e-a71a-35f82871b721)
