### PR TITLE
[#25] [Feat] 자유 게시판 게시글 상세조회 기능 구현

### DIFF
--- a/src/main/java/com/example/dopamines/domain/board/community/free/model/response/FreeBoardReadRes.java
+++ b/src/main/java/com/example/dopamines/domain/board/community/free/model/response/FreeBoardReadRes.java
@@ -1,11 +1,15 @@
 package com.example.dopamines.domain.board.community.free.model.response;
 
+import com.example.dopamines.domain.board.community.free.model.entity.FreeComment;
+import com.example.dopamines.domain.board.community.free.model.entity.FreeLike;
 import com.example.dopamines.domain.user.model.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+@Getter
 @Builder
 public class FreeBoardReadRes {
     private Long idx;
@@ -17,4 +21,7 @@ public class FreeBoardReadRes {
     private String author; // user_nickname
     private String image;
     private LocalDateTime created_at;
+    private int likeCount;
+
+    private List<FreeCommentReadRes> freeCommentList;
 }

--- a/src/main/java/com/example/dopamines/domain/board/community/free/model/response/FreeCommentReadRes.java
+++ b/src/main/java/com/example/dopamines/domain/board/community/free/model/response/FreeCommentReadRes.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -14,4 +15,6 @@ public class FreeCommentReadRes {
     private String author;
     private LocalDateTime createdAt;
     private Integer likeCount;
+    private List<FreeRecommentReadRes> recommentList;
+
 }

--- a/src/main/java/com/example/dopamines/domain/board/community/free/service/FreeBoardService.java
+++ b/src/main/java/com/example/dopamines/domain/board/community/free/service/FreeBoardService.java
@@ -1,10 +1,14 @@
 package com.example.dopamines.domain.board.community.free.service;
 
 import com.example.dopamines.domain.board.community.free.model.entity.FreeBoard;
+import com.example.dopamines.domain.board.community.free.model.entity.FreeComment;
+import com.example.dopamines.domain.board.community.free.model.entity.FreeRecomment;
 import com.example.dopamines.domain.board.community.free.model.request.FreeBoardReq;
 import com.example.dopamines.domain.board.community.free.model.request.FreeBoardUpdateReq;
 import com.example.dopamines.domain.board.community.free.model.response.FreeBoardReadRes;
 import com.example.dopamines.domain.board.community.free.model.response.FreeBoardRes;
+import com.example.dopamines.domain.board.community.free.model.response.FreeCommentReadRes;
+import com.example.dopamines.domain.board.community.free.model.response.FreeRecommentReadRes;
 import com.example.dopamines.domain.board.community.free.repository.FreeBoardRepository;
 import com.example.dopamines.domain.user.model.entity.User;
 import com.example.dopamines.global.common.BaseException;
@@ -51,6 +55,32 @@ public class FreeBoardService {
     public FreeBoardReadRes read(Long idx) {
         FreeBoard freeBoard = freeBoardRepository.findById(idx).orElseThrow(() -> new BaseException(COMMUNITY_BOARD_NOT_FOUND));
 
+        List<FreeCommentReadRes> freeCommentReadResList = new ArrayList<>();
+        for(FreeComment freeComment : freeBoard.getComments()){
+            List<FreeRecommentReadRes> freeRecommentReadResList = new ArrayList<>();
+            for(FreeRecomment freeRecomment : freeComment.getFreeRecomments()){
+                freeRecommentReadResList.add(FreeRecommentReadRes.builder()
+                        .idx(freeRecomment.getIdx())
+                        .freeBoardIdx(freeBoard.getIdx())
+                        .commentIdx(freeRecomment.getFreeComment().getIdx())
+                        .content(freeRecomment.getContent())
+                        .author(freeRecomment.getUser().getNickname())
+                        .createdAt(freeRecomment.getCreatedAt())
+                        .likeCount(freeRecomment.getLikes().size())
+                        .build());
+            }
+            freeCommentReadResList.add(FreeCommentReadRes.builder()
+                    .idx(freeComment.getIdx())
+                    .freeBoardIdx(freeBoard.getIdx())
+                    .content(freeComment.getContent())
+                    .author(freeComment.getUser().getNickname())
+                    .createdAt(freeComment.getCreatedAt())
+                    .likeCount(freeComment.getLikes().size())
+                    .recommentList(freeRecommentReadResList)
+                    .build());
+
+        }
+
         return FreeBoardReadRes.builder()
                 .idx(freeBoard.getIdx())
                 .title(freeBoard.getTitle())
@@ -58,6 +88,8 @@ public class FreeBoardService {
                 .author(freeBoard.getUser().getNickname())
                 .image(freeBoard.getImage())
                 .created_at(LocalDateTime.now())
+                .likeCount(freeBoard.getLikes().size())
+                .freeCommentList(freeCommentReadResList)
                 .build();
     }
 


### PR DESCRIPTION
## 💭 연관된 이슈
#25 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
자유 게시판의 게시글의 상세 조회 기능을 구현한다.
<!-- Resolves: #(Isuue Number) -->

<br>

## ✅ 주요구현 기능
- 게시글 조회로 해당 게시글, 댓글, 대댓글, 댓글좋아요, 대댓글 좋아요까지 조회할 수 있다.
<br>

## 🍪 수정이 되면 좋은 것들

<br>

